### PR TITLE
Always render recruitment banner when enabled

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -21,20 +21,21 @@ function generateSections(formData) {
   const sections = [];
 
   // Bannière de recrutement
-  if (formData.showRecruitmentBanner && (
-    formData.recruiterFirstName || formData.recruiterLastName ||
-    formData.recruiterPosition || formData.recruiterPhone ||
-    formData.recruiterEmail || formData.companyName ||
-    formData.companyLogoUrl || formData.bannerMessage
-  )) {
+  if (formData.showRecruitmentBanner) {
     const bannerStyle = formData.bannerStyle || 'modern';
     const bannerColor = formData.bannerColor || '#3B82F6';
     const bannerHeight = formData.bannerHeight || 50;
     const bannerImageUrl = formData.bannerImageUrl || '';
-    
+
     sections.push({
       type: 'recruitment-banner',
-      content: generateRecruitmentBanner(formData, bannerStyle, bannerColor, bannerHeight, bannerImageUrl),
+      content: generateRecruitmentBanner(
+        formData,
+        bannerStyle,
+        bannerColor,
+        bannerHeight,
+        bannerImageUrl
+      ),
       height: parseInt(bannerHeight) + 10 // hauteur + marge
     });
   }


### PR DESCRIPTION
## Summary
- Always include the recruitment banner in generated sections when the user opts to display it
- Ensure the banner content is generated and accounted for in pagination without requiring additional fields

## Testing
- `node verification-banniere.js` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dabc6fd8832b993b1a0a509e030d