### PR TITLE
Disable recruitment banner by default

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -123,7 +123,10 @@ const exampleData = {
       startDate: "2022-08",
       endDate: "2022-12"
     }
-  ]
+  ],
+
+  // Bannière de recrutement désactivée par défaut
+  showRecruitmentBanner: false
 };
 
 // Variables globales
@@ -681,15 +684,23 @@ function populateExampleData() {
   
   // Compétences transversales
   exampleData.softSkills.forEach(skill => addSoftSkill(skill));
-  
+
   // Langues
   exampleData.languages.forEach(lang => addLanguage(lang));
-  
+
   // Certifications
   exampleData.certifications.forEach(cert => addCertification(cert));
-  
+
   // Projets
   exampleData.projects.forEach(project => addProject(project));
+
+  // S'assurer que la bannière de recrutement est désactivée
+  const showBannerCheckbox = document.getElementById('showRecruitmentBanner');
+  const bannerControls = document.getElementById('recruitmentBannerControls');
+  if (showBannerCheckbox && bannerControls) {
+    showBannerCheckbox.checked = false;
+    bannerControls.style.display = 'none';
+  }
 }
 
 // GÉNÉRATION DE L'APERÇU
@@ -1881,8 +1892,12 @@ function initRecruitmentBannerHandlers() {
   // Gestionnaire pour la checkbox d'affichage de la bannière
   const showBannerCheckbox = document.getElementById('showRecruitmentBanner');
   const bannerControls = document.getElementById('recruitmentBannerControls');
-  
+
   if (showBannerCheckbox && bannerControls) {
+    // Par défaut, la bannière est désactivée
+    showBannerCheckbox.checked = false;
+    bannerControls.style.display = 'none';
+
     showBannerCheckbox.addEventListener('change', function() {
       if (this.checked) {
         bannerControls.style.display = 'block';


### PR DESCRIPTION
## Summary
- Ensure recruitment banner checkbox starts unchecked and controls hidden
- Reset example data to keep recruitment banner disabled on load

## Testing
- `node verification-banniere.js` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dd3673b4832ba40835735a4e71b1