### PR TITLE
Limit skill item width to text length

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -560,7 +560,7 @@ label {
 }
 
 .skill-item .range {
-  flex: 0 1 100px;
+  flex: 0 0 100px;
 }
 
 .skill-level {

--- a/css/app.css
+++ b/css/app.css
@@ -543,23 +543,24 @@ label {
 }
 
 .skill-item {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 12px;
   padding: 12px;
   background: #f8fafc;
   border-radius: 6px;
   border: 1px solid #e2e8f0;
+  width: fit-content;
 }
 
 .skill-item input[type="text"] {
-  flex: 1;
-  min-width: 150px;
+  flex: 0 1 auto;
+  width: auto;
+  min-width: 0;
 }
 
 .skill-item .range {
-  flex: 1;
-  min-width: 100px;
+  flex: 0 1 100px;
 }
 
 .skill-level {


### PR DESCRIPTION
## Summary
- prevent skill entries from stretching across the form by letting them size to their content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df2979c0832b86c8a1ec824612b2