### PR TITLE
feat: add block organization tab and page controls

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1832,3 +1832,27 @@ label {
   color: rgba(0, 0, 0, 0.8);
   background: rgba(0, 0, 0, 0.2);
 }
+
+/* Organisation des blocs */
+.block-order-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.block-order-list .block-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  margin-bottom: 6px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+}
+
+.block-order-list .drag-handle {
+  cursor: grab;
+  font-size: 18px;
+  padding-left: 8px;
+}

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <button class="nav-btn" data-form="languages">Langues</button>
         <button class="nav-btn" data-form="certifications">Certifications</button>
         <button class="nav-btn" data-form="projects">Projets</button>
+        <button class="nav-btn" data-form="blocks">Organisation</button>
         <button class="nav-btn" data-form="recruitment">Recrutement</button>
         <button class="nav-btn" data-form="settings">Paramètres</button>
         <button class="nav-btn" data-form="customization">Personnalisation</button>
@@ -169,6 +170,13 @@
           <button type="button" id="btnAddProject" class="btn btn-add">+ Ajouter un projet</button>
         </section>
 
+        <!-- ORGANISATION DES BLOCS -->
+        <section id="blocks" class="form-section">
+          <h2>Organisation des blocs</h2>
+          <p>Glissez pour réorganiser les sections ou décochez pour les masquer.</p>
+          <ul id="block-order-list" class="block-order-list"></ul>
+        </section>
+
         <!-- INFORMATIONS RECRUTEMENT -->
         <section id="recruitment" class="form-section">
           <h2>Informations Recrutement</h2>
@@ -286,6 +294,13 @@
           <div class="form-group">
             <label>Couleur principale</label>
             <input type="color" id="primaryColor" class="input" value="#2563eb">
+          </div>
+          <div class="form-group">
+            <label>Gestion des pages</label>
+            <div style="display: flex; gap: 10px; flex-wrap: wrap;">
+              <button type="button" id="btnAddPage" class="btn btn-small">+ Ajouter une page</button>
+              <button type="button" id="btnRemovePage" class="btn btn-small">- Supprimer la dernière page</button>
+            </div>
           </div>
         </section>
 

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,9 @@ import { initCustomization, applyCurrentCustomization } from './customization.js
 // Import du module de gestion du drag & drop
 import { initDragAndDrop, destroyDragAndDrop } from './drag.js';
 
+// Import du module d'organisation des blocs
+import { initBlocksTab } from './blocks.js';
+
 // Données d'exemple pour pré-remplir le CV
 const exampleData = {
   fullName: "Jean Dupont",
@@ -145,6 +148,7 @@ document.addEventListener('DOMContentLoaded', function() {
   loadSavedApiKey();
   populateExampleData();
   generatePreview();
+  initBlocksTab();
   
   // Initialiser la personnalisation de manière asynchrone
   initCustomizationAsync();
@@ -302,6 +306,8 @@ function initFormHandlers() {
   addSafeListener('btnAddLanguage', 'click', addLanguage);
   addSafeListener('btnAddCertification', 'click', addCertification);
   addSafeListener('btnAddProject', 'click', addProject);
+  addSafeListener('btnAddPage', 'click', () => window.addNewPage());
+  addSafeListener('btnRemovePage', 'click', () => window.removeLastPage());
   
   // Boutons d'action
   addSafeListener('btnAutoFillAI', 'click', autoFillWithAI);

--- a/js/blocks.js
+++ b/js/blocks.js
@@ -1,0 +1,70 @@
+// Gestion de l'onglet de disposition des blocs
+
+export function initBlocksTab() {
+  const list = document.getElementById('block-order-list');
+  if (!list) return;
+
+  const availableSections = [
+    { type: 'recruitment-banner', label: 'Bannière de recrutement' },
+    { type: 'header', label: 'En-tête' },
+    { type: 'summary', label: 'Résumé' },
+    { type: 'experience', label: 'Expérience' },
+    { type: 'education', label: 'Formation' },
+    { type: 'skills', label: 'Compétences' }
+  ];
+
+  const hidden = JSON.parse(localStorage.getItem('cv-hidden-sections') || '[]');
+  const savedOrder = JSON.parse(localStorage.getItem('cv-section-order') || '[]');
+
+  const ordered = availableSections.slice();
+  if (savedOrder.length > 0) {
+    ordered.sort((a, b) => {
+      const ia = savedOrder.indexOf(a.type);
+      const ib = savedOrder.indexOf(b.type);
+      if (ia === -1 && ib === -1) return 0;
+      if (ia === -1) return 1;
+      if (ib === -1) return -1;
+      return ia - ib;
+    });
+  }
+
+  ordered.forEach(sec => {
+    const li = document.createElement('li');
+    li.className = 'block-item';
+    li.dataset.section = sec.type;
+    li.innerHTML = `
+      <label class="checkbox-label">
+        <input type="checkbox" class="block-visibility" ${hidden.includes(sec.type) ? '' : 'checked'}>
+        <span class="checkmark"></span>
+        ${sec.label}
+      </label>
+      <span class="drag-handle">⋮⋮</span>
+    `;
+    list.appendChild(li);
+  });
+
+  if (window.Sortable) {
+    Sortable.create(list, {
+      animation: 150,
+      handle: '.drag-handle',
+      onEnd: saveOrder
+    });
+  }
+
+  list.addEventListener('change', saveVisibility);
+
+  function saveOrder() {
+    const order = Array.from(list.querySelectorAll('.block-item')).map(i => i.dataset.section);
+    localStorage.setItem('cv-section-order', JSON.stringify(order));
+    window.dispatchEvent(new CustomEvent('regeneratePreview'));
+  }
+
+  function saveVisibility() {
+    const hiddenSections = Array.from(list.querySelectorAll('.block-item'))
+      .filter(item => !item.querySelector('.block-visibility').checked)
+      .map(item => item.dataset.section);
+    localStorage.setItem('cv-hidden-sections', JSON.stringify(hiddenSections));
+    window.dispatchEvent(new CustomEvent('regeneratePreview'));
+  }
+}
+

--- a/js/preview.js
+++ b/js/preview.js
@@ -2,7 +2,7 @@ import { initDragAndDrop } from './drag.js';
 
 export function generatePreview(formData) {
   const previewContainer = document.getElementById('cv-preview');
-  
+
   // Générer le contenu des sections
   const sections = generateSections(formData);
   
@@ -21,9 +21,10 @@ export function generatePreview(formData) {
 
 function generateSections(formData) {
   const sections = [];
+  const hiddenSections = JSON.parse(localStorage.getItem('cv-hidden-sections') || '[]');
 
   // Bannière de recrutement
-  if (formData.showRecruitmentBanner) {
+  if (formData.showRecruitmentBanner && !hiddenSections.includes('recruitment-banner')) {
     const bannerStyle = formData.bannerStyle || 'modern';
     const bannerColor = formData.bannerColor || '#3B82F6';
     const bannerHeight = formData.bannerHeight || 50;
@@ -43,23 +44,25 @@ function generateSections(formData) {
   }
 
   // En-tête
-  sections.push({
-    type: 'header',
-    content: `
-      <div class="cv-section sortable" data-section="header">
-        <div class="drag-handle">⋮⋮</div>
-        <div class="cv-header">
-          <h1 contenteditable="false">${formData.fullName || ''}</h1>
-          <p contenteditable="false">${formData.jobTitle || ''}</p>
-          <p contenteditable="false">${formData.email || ''} | ${formData.phone || ''} | ${formData.address || ''}</p>
+  if (!hiddenSections.includes('header')) {
+    sections.push({
+      type: 'header',
+      content: `
+        <div class="cv-section sortable" data-section="header">
+          <div class="drag-handle">⋮⋮</div>
+          <div class="cv-header">
+            <h1 contenteditable="false">${formData.fullName || ''}</h1>
+            <p contenteditable="false">${formData.jobTitle || ''}</p>
+            <p contenteditable="false">${formData.email || ''} | ${formData.phone || ''} | ${formData.address || ''}</p>
+          </div>
         </div>
-      </div>
-    `,
-    height: 60
-  });
+      `,
+      height: 60
+    });
+  }
 
   // Résumé
-  if (formData.summary) {
+  if (formData.summary && !hiddenSections.includes('summary')) {
     sections.push({
       type: 'summary',
       content: `
@@ -74,7 +77,7 @@ function generateSections(formData) {
   }
 
   // Expérience
-  if (formData.experience && formData.experience.length > 0) {
+  if (formData.experience && formData.experience.length > 0 && !hiddenSections.includes('experience')) {
     let experienceContent = '<div class="cv-section sortable" data-section="experience"><div class="drag-handle">⋮⋮</div><h2 contenteditable="false">Expérience Professionnelle</h2>';
     let experienceHeight = 30; // titre
     let experienceItems = 0;
@@ -113,7 +116,7 @@ function generateSections(formData) {
   }
 
   // Formation
-  if (formData.education && formData.education.length > 0) {
+  if (formData.education && formData.education.length > 0 && !hiddenSections.includes('education')) {
     let educationContent = '<div class="cv-section sortable" data-section="education"><div class="drag-handle">⋮⋮</div><h2 contenteditable="false">Formation</h2>';
     let educationHeight = 30;
     let educationItems = 0;
@@ -152,7 +155,7 @@ function generateSections(formData) {
   }
 
   // Compétences
-  if (formData.skills) {
+  if (formData.skills && !hiddenSections.includes('skills')) {
     sections.push({
       type: 'skills',
       content: `
@@ -316,4 +319,13 @@ window.addNewPage = function() {
   localStorage.setItem('cv-max-pages', (currentMax + 1).toString());
   window.dispatchEvent(new CustomEvent('regeneratePreview'));
 
+};
+
+// Fonction pour supprimer la dernière page
+window.removeLastPage = function() {
+  const currentMax = parseInt(localStorage.getItem('cv-max-pages') || '2');
+  if (currentMax > 1) {
+    localStorage.setItem('cv-max-pages', (currentMax - 1).toString());
+    window.dispatchEvent(new CustomEvent('regeneratePreview'));
+  }
 };


### PR DESCRIPTION
## Summary
- add "Organisation" tab with drag-and-drop list to reorder or hide CV sections
- support hiding sections in preview generation
- add controls to add or remove pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/app.js`
- `node --check js/blocks.js`
- `node --check js/preview.js`

------
https://chatgpt.com/codex/tasks/task_e_68a6e546be28832ba4bb8acd4d03beab