### PR TITLE
Réduire la taille des blocs d'organisation

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1840,14 +1840,16 @@ label {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .block-order-list .block-item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 8px;
-  margin-bottom: 6px;
+  gap: 6px;
+  padding: 4px 8px;
   background: #fff;
   border: 1px solid #e5e7eb;
   border-radius: 4px;
@@ -1856,5 +1858,5 @@ label {
 .block-order-list .drag-handle {
   cursor: grab;
   font-size: 18px;
-  padding-left: 8px;
+  padding-left: 0;
 }


### PR DESCRIPTION
## Summary
- Ajuste l'affichage des blocs d'organisation pour qu'ils s'adaptent à leur contenu
- Supprime l'espacement excessif et réduit le padding pour éviter les tuiles trop grandes

## Testing
- `npm test` *(échec : package.json absent)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e8a0b430832bbb5347e6255e28e1