### PR TITLE
Clean PDF export preview

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1792,7 +1792,17 @@ function exportToPDF() {
     alert('Erreur: Impossible de trouver le contenu du CV');
     return;
   }
-  
+
+  // Préparer l'aperçu pour une exportation propre
+  const wasInEditMode = cvPreview.classList.contains('edit-mode');
+  if (wasInEditMode) {
+    cvPreview.classList.remove('edit-mode');
+  }
+  const overflowIndicators = Array.from(cvPreview.querySelectorAll('.page-overflow-indicator'));
+  overflowIndicators.forEach(indicator => {
+    indicator.style.display = 'none';
+  });
+
   // Afficher un indicateur de chargement
   const button = document.getElementById('btnExport');
   const originalText = button.textContent;
@@ -1842,6 +1852,12 @@ function exportToPDF() {
   }).finally(() => {
     button.textContent = originalText;
     button.disabled = false;
+    overflowIndicators.forEach(indicator => {
+      indicator.style.display = '';
+    });
+    if (wasInEditMode) {
+      cvPreview.classList.add('edit-mode');
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Hide page overflow indicators before generating the PDF
- Temporarily disable edit mode during export to avoid extra UI in PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e96c9ff0832bb3ec59580d8384c2