### PR TITLE
Allow fine-grained banner sizing

### DIFF
--- a/BANNIERE-RECRUTEMENT.md
+++ b/BANNIERE-RECRUTEMENT.md
@@ -15,7 +15,8 @@
   - **Corporate** : Dégradé horizontal avec bordure latérale
 
 - **Couleur personnalisable** : Sélecteur de couleur avec aperçu en temps réel
-- **Hauteur ajustable** : Slider de 20mm à 80mm avec affichage de la valeur
+- **Hauteur ajustable** : Slider de 20mm à 80mm par pas de 0,1mm avec affichage de la valeur
+- **Padding adaptatif** : Espacement interne basé sur la taille du texte
 
 ### 3. 🖼️ Gestion des Images
 - **Image de fond** : URL personnalisable pour l'arrière-plan de la bannière
@@ -98,7 +99,7 @@
 - [x] Contrôles s'affichent/se masquent
 - [x] 4 styles de bannière fonctionnels
 - [x] Couleur personnalisable
-- [x] Hauteur ajustable
+- [x] Hauteur ajustable (pas de 0,1mm)
 - [x] Image de fond supportée
 - [x] Logo d'entreprise affiché
 - [x] Drag & drop fonctionnel

--- a/css/app.css
+++ b/css/app.css
@@ -1674,7 +1674,7 @@ label {
   overflow: hidden;
   display: flex;
   align-items: center;
-  padding: 15mm 20mm;
+  padding: 1em 2em;
   box-sizing: border-box;
   background-size: cover;
   background-position: center;

--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
             <!-- Position et taille -->
             <div class="form-group">
               <label for="bannerHeight">Hauteur de la bannière (mm)</label>
-              <input type="range" id="bannerHeight" name="bannerHeight" class="range-input" min="20" max="80" value="50">
+              <input type="range" id="bannerHeight" name="bannerHeight" class="range-input" min="20" max="80" step="0.1" value="50">
               <span class="range-value">50mm</span>
             </div>
 

--- a/js/preview.js
+++ b/js/preview.js
@@ -39,7 +39,7 @@ function generateSections(formData) {
         bannerHeight,
         bannerImageUrl
       ),
-      height: parseInt(bannerHeight) + 10 // hauteur + marge
+      height: parseFloat(bannerHeight) + 10 // hauteur + marge
     });
   }
 


### PR DESCRIPTION
## Summary
- let recruitment banner height be adjusted in 0.1 increments
- use text-relative padding so banner respects content size
- document finer banner sizing options

## Testing
- `node verification-banniere.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e9436c94832bb24bbd142adb1f95