### PR TITLE
feat: allow resizing blocks and columns

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1150,6 +1150,24 @@ label {
   background-color: rgba(139, 92, 246, 0.1);
 }
 
+.section-resizer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  cursor: ns-resize;
+}
+
+#column-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--cv-left-column-width) - 3px);
+  width: 6px;
+  cursor: ew-resize;
+}
+
 .drag-handle {
   position: absolute;
   left: -30px;

--- a/js/preview.js
+++ b/js/preview.js
@@ -1,4 +1,5 @@
 import { initDragAndDrop } from './drag.js';
+import { initResizableSections, initResizableColumns } from './resize.js';
 
 export function generatePreview(formData) {
   const previewContainer = document.getElementById('cv-preview');
@@ -14,6 +15,8 @@ export function generatePreview(formData) {
   
   // Initialiser le drag & drop après avoir généré le contenu
   initDragAndDrop();
+  initResizableSections();
+  initResizableColumns();
   
   // Appliquer la personnalisation
   applyCustomizationToPreview();

--- a/js/resize.js
+++ b/js/resize.js
@@ -1,0 +1,73 @@
+export function initResizableSections() {
+  // Remove existing resizers to avoid duplicates
+  document.querySelectorAll('.section-resizer').forEach(r => r.remove());
+
+  const sections = document.querySelectorAll('.cv-section');
+  sections.forEach(section => {
+    section.style.position = section.style.position || 'relative';
+
+    const resizer = document.createElement('div');
+    resizer.className = 'section-resizer';
+    section.appendChild(resizer);
+
+    let startY = 0;
+    let startHeight = 0;
+
+    const onMouseDown = (e) => {
+      e.preventDefault();
+      startY = e.clientY;
+      startHeight = parseInt(window.getComputedStyle(section).height, 10);
+      document.documentElement.addEventListener('mousemove', onMouseMove);
+      document.documentElement.addEventListener('mouseup', onMouseUp);
+    };
+
+    const onMouseMove = (e) => {
+      const dy = e.clientY - startY;
+      section.style.height = `${startHeight + dy}px`;
+    };
+
+    const onMouseUp = () => {
+      document.documentElement.removeEventListener('mousemove', onMouseMove);
+      document.documentElement.removeEventListener('mouseup', onMouseUp);
+    };
+
+    resizer.addEventListener('mousedown', onMouseDown);
+  });
+}
+
+export function initResizableColumns() {
+  const existing = document.getElementById('column-resizer');
+  if (existing) existing.remove();
+
+  const preview = document.getElementById('cv-preview');
+  if (!preview || !preview.classList.contains('layout-sidebar')) return;
+
+  const handle = document.createElement('div');
+  handle.id = 'column-resizer';
+  preview.appendChild(handle);
+
+  let startX = 0;
+  let startWidth = 0;
+
+  const onMouseDown = (e) => {
+    startX = e.clientX;
+    startWidth = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--cv-left-column-width'));
+    document.documentElement.addEventListener('mousemove', onMouseMove);
+    document.documentElement.addEventListener('mouseup', onMouseUp);
+  };
+
+  const onMouseMove = (e) => {
+    const dx = e.clientX - startX;
+    const previewWidth = preview.getBoundingClientRect().width;
+    let newWidth = ((startWidth / 100 * previewWidth + dx) / previewWidth) * 100;
+    newWidth = Math.max(10, Math.min(80, newWidth));
+    document.documentElement.style.setProperty('--cv-left-column-width', `${newWidth}%`);
+  };
+
+  const onMouseUp = () => {
+    document.documentElement.removeEventListener('mousemove', onMouseMove);
+    document.documentElement.removeEventListener('mouseup', onMouseUp);
+  };
+
+  handle.addEventListener('mousedown', onMouseDown);
+}


### PR DESCRIPTION
## Summary
- enable resizing of blocks directly in the live preview
- add drag handle to adjust left column width in sidebar layout
- wire in new resizer initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eac9ecc8832b89f1f59bd4aa64bd