### PR TITLE
Allow recruitment banner height to collapse

### DIFF
--- a/BANNIERE-RECRUTEMENT.md
+++ b/BANNIERE-RECRUTEMENT.md
@@ -15,7 +15,7 @@
   - **Corporate** : Dégradé horizontal avec bordure latérale
 
 - **Couleur personnalisable** : Sélecteur de couleur avec aperçu en temps réel
-- **Hauteur ajustable** : Slider de 20mm à 80mm par pas de 0,1mm avec affichage de la valeur
+- **Hauteur ajustable** : Slider de 0mm à 80mm par pas de 0,1mm avec affichage de la valeur
 - **Padding adaptatif** : Espacement interne basé sur la taille du texte
 
 ### 3. 🖼️ Gestion des Images

--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
             <!-- Position et taille -->
             <div class="form-group">
               <label for="bannerHeight">Hauteur de la bannière (mm)</label>
-              <input type="range" id="bannerHeight" name="bannerHeight" class="range-input" min="20" max="80" step="0.1" value="50">
+              <input type="range" id="bannerHeight" name="bannerHeight" class="range-input" min="0" max="80" step="0.1" value="50">
               <span class="range-value">50mm</span>
             </div>
 


### PR DESCRIPTION
## Summary
- Allow recruitment banner slider to reach 0mm for minimal height
- Update documentation to reflect new 0–80mm range

## Testing
- `node verification-banniere.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ebafa2c0832ba4a4d92b317fa484